### PR TITLE
Incorrect AppKernel.php Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new Zoerb\Bundle\ZoerbFilerevBundle(),
+        new Zoerb\Bundle\FilerevBundle\ZoerbFilerevBundle(),
     );
 }
 ```


### PR DESCRIPTION
The mentioned namespace in README.md is incorrect.
