### PR TITLE
Update parameters.yml for Symfony 3.1

### DIFF
--- a/Resources/config/parameters.yml
+++ b/Resources/config/parameters.yml
@@ -1,2 +1,2 @@
 parameters:
-    zoerb_filerev.root_dir: %kernel.root_dir%/../web
+    zoerb_filerev.root_dir: '%kernel.root_dir%/../web'


### PR DESCRIPTION
Not quoting the scalar "%kernel.root_dir%/../web" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.
